### PR TITLE
Bump WindowsAzure.Storage to match newer Episerver versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+﻿# Change log
+
+## 3.0.0
+
+- Upgrade WindowsAzure.Storage version to match newer Episerver versions
+
+
+## 2.0.4
+
+- Add try-catch around CloudTable.CreateIfNotExists()
+  See:
+  https://stackoverflow.com/questions/48893519/azure-table-storage-exception-409-conflict-unexpected
+
+
+## 2.0.3
+
+- Add threshold of 1000 log entries per batch to fix performance bottle neck
+
+## 2.0.2
+
+- Downgrade Microsoft.WindowsAzure.Storage to accomply with the present latest Episerver.Azure package
+
+## 2.0.1
+
+- Upgrade WindowsAzure.Storage to 9.0.0
+
+## 1.0.1
+
+- Use unescaped log4net property names to filter columns in AzureTableAppender
+
+## 1.0.0
+
+Initial version

--- a/log4net.Azure/AzureAppendBlobAppender.cs
+++ b/log4net.Azure/AzureAppendBlobAppender.cs
@@ -9,7 +9,7 @@ using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using log4net.Appender.Language;
 using log4net.Core;
-using Microsoft.Azure;
+using Microsoft.WindowsAzure;
 
 namespace log4net.Appender
 {

--- a/log4net.Azure/AzureBlobAppender.cs
+++ b/log4net.Azure/AzureBlobAppender.cs
@@ -7,7 +7,7 @@ using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using log4net.Appender.Language;
 using log4net.Core;
-using Microsoft.Azure;
+using Microsoft.WindowsAzure;
 
 namespace log4net.Appender
 {

--- a/log4net.Azure/AzureQueueAppender.cs
+++ b/log4net.Azure/AzureQueueAppender.cs
@@ -1,7 +1,7 @@
 ﻿using log4net.Appender.Language;
 using log4net.Core;
 using log4net.Layout;
-using Microsoft.Azure;
+using Microsoft.WindowsAzure;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Queue;
 using System;

--- a/log4net.Azure/Util.cs
+++ b/log4net.Azure/Util.cs
@@ -1,5 +1,5 @@
 ﻿using log4net.Appender.Language;
-using Microsoft.Azure;
+using Microsoft.WindowsAzure;
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/log4net.Azure/log4net.Appender.Azure.csproj
+++ b/log4net.Azure/log4net.Appender.Azure.csproj
@@ -59,8 +59,8 @@
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.8.7.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.9.0.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/log4net.Azure/packages.config
+++ b/log4net.Azure/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="8.7.0" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="9.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR bumps WindowsAzure.Storage to the latest version available to make it possible to upgrader Episerver to its latest versions and therefore bypass the following issue:

![bild](https://user-images.githubusercontent.com/14070368/74158258-0aaa1200-4c1a-11ea-98f0-e20195a80db5.png)

The following note was supplied when upgrading though which might be of significance in the future:

> NOTE: As of version 9.4.0, this library has been split into multiple parts and replaced:  See https://www.nuget.org/packages/Microsoft.Azure.Storage.Blob/, https://www.nuget.org/packages/Microsoft.Azure.Storage.File/, https://www.nuget.org/packages/Microsoft.Azure.Storage.Queue/, and https://www.nuget.org/packages/Microsoft.Azure.Storage.Common/.